### PR TITLE
drush bash variable not used and blt references.

### DIFF
--- a/factory-hooks/db-update/db-update.sh
+++ b/factory-hooks/db-update/db-update.sh
@@ -26,19 +26,16 @@ domain="$4"
 # Drush executable:
 drush="/mnt/www/html/$sitegroup.$env/vendor/bin/drush"
 
-# BLT wants the name of the website, which we can derive from its internal
+# drush wants the name of the website, which we can derive from its internal
 # domain name. Use the uri.php file provided by the acsf module to get the
 # internal domain name based on the site, environment and db role arguments.
 uri=`/usr/bin/env php /mnt/www/html/$sitegroup.$env/hooks/acquia/uri.php $sitegroup $env $db_role`
 
 echo "Running DRS deploy tasks on $uri domain in $env environment on the $sitegroup subscription."
 
-# Run blt drupal:update tasks. The trailing slash behind the domain works
+# Run drush drupal:update tasks. The trailing slash behind the domain works
 # around a bug in Drush < 9.6 for path based domains: "domain.com/subpath/" is
 # considered a valid URI but "domain.com/subpath" is not.
-drush drupal:update --uri=$domain/ --verbose --no-interaction
-
-# Clean up the drush cache directory.
-echo "Removing temporary drush cache files."
+${drush} drupal:update --uri=$domain/ --verbose --no-interaction
 
 set +v

--- a/factory-hooks/db-update/db-update.sh
+++ b/factory-hooks/db-update/db-update.sh
@@ -26,12 +26,7 @@ domain="$4"
 # Drush executable:
 drush="/mnt/www/html/$sitegroup.$env/vendor/bin/drush"
 
-# drush wants the name of the website, which we can derive from its internal
-# domain name. Use the uri.php file provided by the acsf module to get the
-# internal domain name based on the site, environment and db role arguments.
-uri=`/usr/bin/env php /mnt/www/html/$sitegroup.$env/hooks/acquia/uri.php $sitegroup $env $db_role`
-
-echo "Running DRS deploy tasks on $uri domain in $env environment on the $sitegroup subscription."
+echo "Running DRS deploy tasks on $domain domain in $env environment on the $sitegroup subscription."
 
 # Run drush drupal:update tasks. The trailing slash behind the domain works
 # around a bug in Drush < 9.6 for path based domains: "domain.com/subpath/" is

--- a/factory-hooks/post-site-install/post-site-install.sh
+++ b/factory-hooks/post-site-install/post-site-install.sh
@@ -2,7 +2,7 @@
 #
 # Factory Hook: post-site-install
 #
-# This is necessary so that blt drupal:install tasks are invoked automatically
+# This is necessary so that drush drupal:install tasks are invoked automatically
 # when a site is created on ACSF.
 #
 # Usage: post-site-install.sh sitegroup env db-role domain
@@ -28,12 +28,12 @@ internal_domain="$4"
 drush="/mnt/www/html/$sitegroup.$env/vendor/bin/drush"
 
 # Execute the updates.
-drush drupal:update --uri=$internal_domain --verbose --no-interaction
+${drush} drupal:update --uri=$internal_domain --verbose --no-interaction
 result=$?
 
 set +v
 
-# Exit with the status of the BLT commmand. If the exit status is non-zero,
+# Exit with the status of the drush commmand. If the exit status is non-zero,
 # Site Factory will send a notification of a partiolly failed install and will
 # stop executing any further post-site-install hook scripts that would be in
 # this directory (and get executed in alphabetical order).


### PR DESCRIPTION
**Motivation**
Seems the shell script had errors and blt commentsµ.

**Proposed changes**
This fix alter `drush` calls to `${drush}` to really use the `drush` variable defined a few lines before (else it's just drush from current PATH which is called.

I also remove blt from comments, and removed to clar-cache comment as you are uin fact not launching the clear cache command (but maybe it would be better to launch it, with the right --uri parameter).

